### PR TITLE
add prittier config, update ESLint config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "semi": true,
+    "singleQuote": true,
+    "trailingComma": "none"
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
     "semi": true,
     "singleQuote": false,
-    "trailingComma": "all"
+    "trailingComma": "all",
+    "endOfLine": "auto"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
     "semi": true,
-    "singleQuote": true,
-    "trailingComma": "none"
+    "singleQuote": false,
+    "trailingComma": "all"
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,10 @@ export default [
     },
     rules: {
       "vue/multi-word-component-names": "off", // Example Vue rule override
+      semi: "off",
+      quotes: "off",
+      "comma-dangle": "off",
+      "prettier/prettier": "error",
     },
   },
 ];


### PR DESCRIPTION
1. added prettier config
2. update es-lint config to ig

Note:
To avoid ESLint and Prettier conflicts, you should:

Let Prettier handle formatting by disabling conflicting ESLint rules.
Use the Prettier plugin for ESLint (which you already do).
Align your ESLint and Prettier configs (e.g., trailing commas, quotes, semicolons).