### PR TITLE
Don't include inactive Task, Experience, Badge, and Item/Reward in Flight Plan

### DIFF
--- a/src/services/rewardServices.js
+++ b/src/services/rewardServices.js
@@ -40,8 +40,17 @@ export default {
   getStatusTypes() {
     return apiClient.get("/reward/types/statusTypes");
   },
-  getAllActiveRewards() {
-    return apiClient.get("/reward/active");
+  getAllActiveRewards(page, pageSize, searchQuery, filters = {}) {
+    return apiClient.get("/reward/active", {
+      params: {
+        page: page,
+        pageSize: pageSize,
+        searchQuery: searchQuery,
+        redemptionType: filters?.redemptionType,
+        sortAttribute: filters?.sortAttribute,
+        sortDirection: filters?.sortDirection,
+      },
+    });
   },
   getAllInactiveRewards() {
     return apiClient.get("/reward/inactive");

--- a/src/services/services.js
+++ b/src/services/services.js
@@ -30,23 +30,22 @@ const apiClient = axios.create({
     return JSON.stringify(data);
   },
   transformResponse: function (data) {
-    data = JSON.parse(data);
-    // if (!data.success && data.code == "expired-session") {
-    //   localStorage.deleteItem("user");
-    // }
-    if (data.message !== undefined && data.message.includes("Unauthorized")) {
-      AuthServices.logoutUser(Utils.getStore("user"))
-        .then(() => {
-          
-          Utils.removeItem("user");
-          Router.push({ name: "login" });
-        })
-        .catch((error) => {
-          console.log("error", error);
-        });
-     
+    if (data) {
+      data = JSON.parse(data);
+      // if (!data.success && data.code == "expired-session") {
+      //   localStorage.deleteItem("user");
+      // }
+      if (data.message !== undefined && data.message.includes("Unauthorized")) {
+        AuthServices.logoutUser(Utils.getStore("user"))
+          .then(() => {
+            Utils.removeItem("user");
+            Router.push({ name: "login" });
+          })
+          .catch((error) => {
+            console.log("error", error);
+          });
+      }
     }
-  
     return data;
   },
 });

--- a/src/views/student/StudentShop.vue
+++ b/src/views/student/StudentShop.vue
@@ -41,7 +41,7 @@ const numCardColumns = computed(() => {
 const pageSize = computed(() => numCardColumns.value * 2);
 
 const fetchRewards = async () => {
-  const response = await rewardServices.getAllRewards(
+  const response = await rewardServices.getAllActiveRewards(
     page.value,
     pageSize.value,
     searchQuery.value,


### PR DESCRIPTION
Making findAllActiveRewards to work exactly like findAll (is returning a 500 in the console but not in the network tab). If you change the method call at linke 44 in StudentShop.vue to getAllRewards it works with no filtering out inactive rewards