### PR TITLE
Update (calendar) Admin cancel event visual response

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -76,6 +76,7 @@ const confirmCancel = async () => {
     await eventServices
       .getRegisteredStudents(eventToCancel.value)
       .then((res) => {
+        if (res.data !== null) {
         res.data.forEach((student) => {
           registeredStudents.push(student.studentId);
 
@@ -91,15 +92,20 @@ const confirmCancel = async () => {
 
           createEventCancelNotification(eventToCancelObject.value, student.user.id, true, 1, student.user.email);
         });
+      }
+
+
       })
       .catch((err) => {
         console.error("Error creating notifcation: ", err);
       });
 
+      if (registeredStudents.length > 0) {
     await eventServices.unregisterStudents(
       eventToCancel.value,
       registeredStudents,
     );
+      }
 
     cancelledEvents.value.push(eventToCancel.value);
     await getEvents();

--- a/src/components/cards/EventCard.vue
+++ b/src/components/cards/EventCard.vue
@@ -196,7 +196,7 @@ const resolvedStatusLabel = computed(() => {
         return "Upcoming";
       case "canceled":
         return "Cancelled";
-      case "passed":
+      case "past":
         return "Passed";
       case "registered":
         return "Upcoming"
@@ -211,7 +211,7 @@ const resolvedStatusLabel = computed(() => {
         return "Checked In";
       case "canceled":
         return "Cancelled";
-      case "passed":
+      case "past":
         return "registered";
       case "registered":
         return "Registered"
@@ -343,14 +343,18 @@ const handleRegistration = () => {
         </v-card-text>
         <v-row v-if="props.adminView && !props.noActions" class="ma-2 float-left">
           <v-btn
-            color="warning"
+            :color='props.event.status !== "Cancelled" && props.event.status !== "Past" ? "warning" : "primary"'
             class="mr-2 cardButton elevation-0"
             @click.stop="editEvent"
           >
-            <v-icon icon="mdi-pencil" color="text" size="x-large"></v-icon>
+            <v-icon 
+            color="text" 
+            size="x-large"
+            :icon='props.event.status !== "Cancelled" && props.event.status !== "Past" ? "mdi-pencil" : "mdi-eye"'>
+            </v-icon>
           </v-btn>
           <v-btn
-            v-if="props.status !== 'grey'"
+            v-if="props.event.status !== 'Cancelled' && props.event.status !== 'Past'"
             color="error"
             class="mr-2 cardButton elevation-0"
             @click.stop="cancelEvent"


### PR DESCRIPTION
Added visual response when an admin cancels an event: -Cancel button disappears
-Event card status, view button appears, and color changes