### PR TITLE
Edit in Experience Link is Required

### DIFF
--- a/src/views/admin/task/TaskAddEditPage.vue
+++ b/src/views/admin/task/TaskAddEditPage.vue
@@ -294,7 +294,7 @@ onMounted(async () => {
         variant="solo"
         rounded="lg"
         label="Additional Instructions Link"
-        :rules="[isLink]"
+        :rules="formData.instructionsLinkDescription ? [isLink] : []"
       ></v-text-field>
       <v-text-field
         v-model="formData.rationale"


### PR DESCRIPTION
Added conditional rule for the additional instructions link to only be required if the additional instructions description is not null